### PR TITLE
Changed Env Var name in pre requisites

### DIFF
--- a/articles/cognitive-services/form-recognizer/quickstarts/dotnet-sdk.md
+++ b/articles/cognitive-services/form-recognizer/quickstarts/dotnet-sdk.md
@@ -37,7 +37,7 @@ Use the Form Recognizer client library for .NET to:
 
 [!INCLUDE [create resource](../includes/create-resource.md)]
 
-After you get a key and endpoint, [create environment variables](https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account#configure-an-environment-variable-for-authentication) for the key and endpoint, named `FORM_RECOGNIZER_KEY` and `FORM_RECOGNIZER_ENDPOINT`, respectively.
+After you get a key and endpoint, [create environment variables](https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account#configure-an-environment-variable-for-authentication) for the key and endpoint, named `FORM_RECOGNIZER_SUBSCRIPTION_KEY` and `FORM_RECOGNIZER_ENDPOINT`, respectively.
 
 ### Create a new C# application
 


### PR DESCRIPTION
Unable to run sample code inside this quickstart without this change - the code references FORM_RECOGNIZER_SUBSCRIPTION_KEY not FORM_RECOGNIZER_KEY